### PR TITLE
Added --adv-heading-text-align

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Adyen Document Viewer is themeable and uses CSS variables that can be overridden
 --adv-heading-font-size: 32px;
 --adv-heading-font-weight: var(--adv-text-font-weight-semi-bold);
 --adv-heading-line-height: 40px;
+--adv-heading-text-align: left; 
 --adv-heading-2-font-size: 24px;
 --adv-heading-2-font-weight: var(--adv-text-font-weight-semi-bold);
 --adv-heading-2-line-height: 32px;

--- a/src/components/Heading/Heading.mixins.scss
+++ b/src/components/Heading/Heading.mixins.scss
@@ -7,6 +7,7 @@
   font-size: var(--adv-heading-font-size);
   font-weight: var(--adv-heading-font-weight);
   line-height: var(--adv-heading-line-height);
+  text-align: var(--adv-heading-text-align);
   margin: 0;
   padding: 0;
 }

--- a/src/style/variables.scss
+++ b/src/style/variables.scss
@@ -80,6 +80,7 @@
   --adv-heading-font-size: 32px;
   --adv-heading-font-weight: var(--adv-text-font-weight-semi-bold);
   --adv-heading-line-height: 40px;
+  --adv-heading-text-align: left;
   --adv-heading-2-font-size: 24px;
   --adv-heading-2-font-weight: var(--adv-text-font-weight-semi-bold);
   --adv-heading-2-line-height: 32px;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
To align the header, I added a new CSS variable called `--adv-heading-text-align`, which has a default value of `left`.
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->
![Screenshot 2025-01-14 at 1 50 15 PM](https://github.com/user-attachments/assets/3c315ad7-26c6-4977-ac4e-97cc052da594)
![Screenshot 2025-01-14 at 1 49 24 PM](https://github.com/user-attachments/assets/c39a7779-ce61-4f89-8f0e-976b878c527b)
![Screenshot 2025-01-14 at 1 50 44 PM](https://github.com/user-attachments/assets/1b2454ca-e493-4d11-9765-1a0b191b67cb)


**Fixed issue**:  <!-- #-prefixed issue number -->
