### PR TITLE
Add 'showSectionNumbering' option

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,13 +29,31 @@ jobs:
       - run: npm i
       - run: npm run build
 
-  test:
+  unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
 
-      - run: npm i
-      - run: npx playwright install
-      - run: npm run test
+      - name: Install dependencies
+        run: npm i
+
+      - name: Run unit tests
+        run: npm run test:unit
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Install Playwright dependencies
+        run: npx playwright install
+
+      - name: Run E2E tests
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ Include the script and stylesheet to a `.html` file
 
 You can customize the behavior of `AdyenDocumentViewer` by passing options during initialization.
 
-| Option            | Description                                             | Default     |
-| ----------------- | ------------------------------------------------------- | ----------- |
-| `onExpandSection` | Callback function triggered when a section is expanded. | `undefined` |
-| `multiple`        | Allow multiple sections to be expanded simultaneously.  | `false`     |
+| Option                 | Description                                             | Default     |
+|------------------------| ------------------------------------------------------- | ----------- |
+| `onExpandSection`      | Callback function triggered when a section is expanded. | `undefined` |
+| `multiple`             | Allow multiple sections to be expanded simultaneously.  | `false`     |
+| `showSectionNumbering` | Enable or disable section numbering.                    | `false`     |
+
 
 You can provide an object with the options as the second parameter when creating an instance of `AdyenDocumentViewer`:
 
@@ -62,6 +64,7 @@ You can provide an object with the options as the second parameter when creating
 const options = {
   onExpandSection: (sectionTitle) => console.log(`Section ${sectionTitle} expanded`),
   multiple: true,
+  showSectionNumbering: true,
 };
 
 const documentViewer = new AdyenDocumentViewer('#test', options);

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test": "playwright test",
     "test:debug": "playwright test --debug",
     "test:ui": "playwright test --ui",
+    "test:unit": "vitest",
     "types:build": "tsc --project tsconfig-build.json",
     "types:check": "tsc",
     "types:watch": "tsc --watch --preserveWatchOutput"
@@ -53,7 +54,8 @@
     "stylelint-config-sass-guidelines": "^9.0.1",
     "stylelint-scss": "^4.2.0",
     "typescript": "^5.3.3",
-    "vite": "^4.5.1"
+    "vite": "^4.5.1",
+    "vitest": "^2.1.9"
   },
   "license": "MIT",
   "repository": {

--- a/playground/example.js
+++ b/playground/example.js
@@ -6,6 +6,7 @@ import exampleDocument from './mock-data';
 const documentViewer = new AdyenDocumentViewer('#document-viewer', {
   onExpandSection: (sectionTitle) => console.log(`${sectionTitle} expanded`),
   multiple: false,
+  showSectionNumbering: true,
 });
 
 documentViewer.render(exampleDocument);

--- a/playground/mock-data.js
+++ b/playground/mock-data.js
@@ -65,7 +65,7 @@ export default {
                   contentElements: [
                     {
                       type: 'text',
-                      content: 'Below we have a list:',
+                      content: 'Below we have a list of items:',
                       styles: [],
                     },
                   ],
@@ -80,7 +80,7 @@ export default {
                       content: [
                         {
                           type: 'text',
-                          content: 'first item in BI.',
+                          content: 'First item in bold and italic.',
                           styles: ['BOLD', 'ITALIC'],
                         },
                       ],
@@ -90,7 +90,7 @@ export default {
                       content: [
                         {
                           type: 'text',
-                          content: 'Second item:',
+                          content: 'Second item with a nested list:',
                           styles: [],
                         },
                       ],
@@ -104,7 +104,7 @@ export default {
                             content: [
                               {
                                 type: 'text',
-                                content: 'First Sub item:',
+                                content: 'First sub-item in the nested list.',
                                 styles: [],
                               },
                             ],
@@ -117,7 +117,7 @@ export default {
                                 referencedLabel: '2',
                                 displayText: {
                                   type: 'text',
-                                  content: 'Second section',
+                                  content: 'Second section reference',
                                   styles: [],
                                 },
                               },
@@ -128,7 +128,7 @@ export default {
                             content: [
                               {
                                 type: 'text',
-                                content: 'Third List item:',
+                                content: 'Third sub-item with another nested list:',
                                 styles: [],
                               },
                             ],
@@ -142,8 +142,8 @@ export default {
                                   content: [
                                     {
                                       type: 'text',
-                                      content: 'First Sub Sub item:',
-                                      styles: '[Array(0)]',
+                                      content: 'First sub-sub-item in the deeper list.',
+                                      styles: [],
                                     },
                                   ],
                                   subList: null,
@@ -184,22 +184,21 @@ export default {
                 {
                   type: 'text',
                   content:
-                    ' Lorem Ipsum is simply dummy text of the printing and typesetting industry. ',
+                    'This paragraph provides additional placeholder text for the second section.',
                   styles: [],
                 },
                 {
                   type: 'weblink',
-                  url: 'https://www.lipsum.com',
+                  url: 'https://www.example.com',
                   displayText: {
                     type: 'text',
-                    content: 'Lorem Ipsum',
+                    content: 'Example Link',
                     styles: [],
                   },
                 },
                 {
                   type: 'text',
-                  content:
-                    ' has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.',
+                  content: ' It serves as a distinct piece of content for testing purposes.',
                   styles: [],
                 },
                 {
@@ -269,7 +268,7 @@ export default {
                   },
                   title: {
                     type: 'text',
-                    content: 'Lorem Ipsum',
+                    content: 'Sample Table',
                     styles: [],
                   },
                   style: {
@@ -277,6 +276,69 @@ export default {
                     alignment: 'LEFT',
                   },
                   label: 'tableReference',
+                },
+              ],
+            },
+            {
+              type: 'section',
+              title: {
+                type: 'text',
+                content: 'This is a section inside the second section',
+                styles: [],
+              },
+              label: '1',
+              contentElements: [
+                {
+                  type: 'paragraph',
+                  contentElements: [
+                    {
+                      type: 'text',
+                      content: 'This is unique content for a subsection paragraph.',
+                      styles: [],
+                    },
+                  ],
+                },
+                {
+                  type: 'section',
+                  title: {
+                    type: 'text',
+                    content: 'This is a subsection ',
+                    styles: [],
+                  },
+                  label: '1',
+                  contentElements: [
+                    {
+                      type: 'paragraph',
+                      contentElements: [
+                        {
+                          type: 'text',
+                          content: 'This is placeholder text for a nested subsection.',
+                          styles: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'section',
+              title: {
+                type: 'text',
+                content: 'This is another section inside the second section',
+                styles: [],
+              },
+              label: '1',
+              contentElements: [
+                {
+                  type: 'paragraph',
+                  contentElements: [
+                    {
+                      type: 'text',
+                      content: 'This paragraph contains additional distinct mock text.',
+                      styles: [],
+                    },
+                  ],
                 },
               ],
             },

--- a/playground/showSectionNumbering.html
+++ b/playground/showSectionNumbering.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Adyen Document Viewer Example</title>
+
+    <link rel="stylesheet" href="/adyen-document-viewer.min.css" />
+  </head>
+  <body>
+    <div id="document-viewer"></div>
+
+    <script type="module">
+      import AdyenDocumentViewer from '/adyen-document-viewer.min.mjs?url';
+      import exampleDocument from './mock-data';
+
+      const documentViewer = new AdyenDocumentViewer('#document-viewer', {
+        showSectionNumbering: true,
+      });
+
+      documentViewer.render(exampleDocument);
+    </script>
+  </body>
+</html>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ const IS_CI = Boolean(process.env.CI);
  * See https://playwright.dev/docs/test-configuration.
  */
 const config: PlaywrightTestConfig = {
-  testDir: './tests',
+  testDir: './tests/e2e',
   timeout: 5 * 1000,
   expect: {
     timeout: 1000,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import { h, render } from 'preact';
 
 import DocumentViewer from './DocumentViewer';
 import { AdyenDocumentViewerOptions, Document } from './types';
+import { addSectionNumbering } from './utils/preprocessDocument';
 
 export type * from './types';
 
@@ -29,6 +30,7 @@ export default class AdyenDocumentViewer {
     this.options = {
       onExpandSection: options.onExpandSection ?? undefined,
       multiple: options.multiple ?? false,
+      showSectionNumbering: options.showSectionNumbering ?? false,
     };
   }
 
@@ -37,9 +39,13 @@ export default class AdyenDocumentViewer {
    * @param document - The JSON document
    */
   render(document: Document): void {
+    const processedDocument = this.options.showSectionNumbering
+      ? addSectionNumbering(document)
+      : document;
+
     render(
       <DocumentViewer
-        document={document}
+        document={processedDocument}
         onExpandSection={this.options.onExpandSection}
         multiple={this.options.multiple}
       />,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,7 +27,11 @@ export interface TopLevelElement {
 // Elements
 export type Document = ElementWithInnerContent & { title: Text };
 type Chapter = ElementWithInnerContent & { type: ElementTypes.Chapter; title: Text };
-type Section = ElementWithInnerContent & { type: ElementTypes.Section; title: Text; label: string };
+export type Section = ElementWithInnerContent & {
+  type: ElementTypes.Section;
+  title: Text;
+  label: string;
+};
 type Paragraph = ElementWithInnerContent & { type: ElementTypes.Paragraph };
 type Text = { type: ElementTypes.Text; content: string; styles?: TextStyle[] };
 type Weblink = { type: ElementTypes.Weblink; url: string; displayText: Text };
@@ -90,4 +94,5 @@ export type InternalReferenceProps = Omit<InternalReference, 'type'>;
 export interface AdyenDocumentViewerOptions {
   onExpandSection?: (sectionId: string) => void;
   multiple?: boolean;
+  showSectionNumbering?: boolean;
 }

--- a/src/utils/preprocessDocument.ts
+++ b/src/utils/preprocessDocument.ts
@@ -1,0 +1,106 @@
+import { Document, Element, ElementTypes, Section } from '../types';
+
+type NumberingContext = {
+  prefix: string;
+  counter: number;
+  isTopLevel: boolean;
+};
+
+/**
+ * Type guard to check if an element is a Section.
+ */
+function isSection(element: Element): element is Section {
+  return 'type' in element && element.type === ElementTypes.Section;
+}
+
+/**
+ * Type guard to check if an element has nested content elements.
+ */
+function hasContentElements(element: Element): element is Section {
+  return 'contentElements' in element && Array.isArray(element.contentElements);
+}
+
+/**
+ * Generates the numbering for sections or subsections.
+ * @param context - The numbering context.
+ * @returns The generated numbering string.
+ */
+function generateNumbering(context: NumberingContext): string {
+  return context.isTopLevel ? `${context.counter}` : `${context.prefix}${context.counter}`;
+}
+
+/**
+ * Generates the formatted title for a section.
+ * @param currentNumber - The generated numbering string.
+ * @param titleContent - The original title content.
+ * @returns The formatted title string.
+ */
+function generateTitle(currentNumber: string, titleContent: string): string {
+  return `${currentNumber} ${titleContent}`;
+}
+
+/**
+ * Recursively adds numbering to sections and their nested content elements.
+ * @param element - The current element to process.
+ * @param context - The numbering context.
+ * @returns A new element with updated numbering.
+ */
+function addNumberingToSections(element: Element, context: NumberingContext): Element {
+  if (isSection(element)) {
+    const currentNumber = generateNumbering(context);
+
+    const updatedSection: Section = {
+      ...element,
+      title: {
+        ...element.title,
+        content: generateTitle(currentNumber, element.title.content),
+      },
+    };
+
+    context.counter += 1;
+
+    if (hasContentElements(element)) {
+      let subsectionCounter = 1;
+      updatedSection.contentElements = element.contentElements.map((child) => {
+        if (isSection(child)) {
+          const subsectionContext: NumberingContext = {
+            prefix: `${currentNumber}.`,
+            counter: subsectionCounter,
+            isTopLevel: false,
+          };
+          subsectionCounter += 1;
+          return addNumberingToSections(child, subsectionContext);
+        }
+        return child;
+      });
+    }
+
+    return updatedSection;
+  }
+
+  if (hasContentElements(element)) {
+    return {
+      ...element,
+      contentElements: element.contentElements.map((child) =>
+        addNumberingToSections(child, context),
+      ),
+    };
+  }
+
+  return element;
+}
+
+/**
+ * Adds numbering to the sections and subsections of a document.
+ * @param document - The document to process.
+ * @returns A new document with updated numbering.
+ */
+export function addSectionNumbering(document: Document): Document {
+  const context: NumberingContext = { prefix: '', counter: 1, isTopLevel: true };
+  return {
+    ...document,
+    contentElements: document.contentElements.map((element) =>
+      addNumberingToSections(element, context),
+    ),
+  };
+}

--- a/tests/e2e/checkBuiltPackageWorks.test.ts
+++ b/tests/e2e/checkBuiltPackageWorks.test.ts
@@ -5,6 +5,9 @@ import { expect, test } from '@playwright/test';
     await page.goto(`/${importMethod}.html`);
 
     await expect(page.getByRole('heading', { name: 'First chapter' })).toBeVisible();
+
+    await expect(page.getByRole('button', { name: /^1 First section$/ })).not.toBeVisible();
+
     await page.getByRole('button', { name: 'First section' }).click();
 
     await expect(page.getByText('This is a bold and italic example.')).toBeVisible();

--- a/tests/e2e/checkSectionNumberingWorks.test.ts
+++ b/tests/e2e/checkSectionNumberingWorks.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+test('showSectionNumbering should display sections and subsections when Second section is expanded', async ({
+  page,
+}) => {
+  await page.goto('/showSectionNumbering.html');
+
+  await page.getByRole('button', { name: /^2 Second section$/ }).click();
+
+  await expect(
+    page.getByRole('heading', { name: /^2.1 This is a section inside the second section$/ }),
+  ).toBeVisible();
+
+  await expect(
+    page.getByText(/^This is unique content for a subsection paragraph\.$/),
+  ).toBeVisible();
+
+  await expect(page.getByRole('heading', { name: /^2.1.1 This is a subsection$/ })).toBeVisible();
+
+  await expect(
+    page.getByText(/^This is placeholder text for a nested subsection\.$/),
+  ).toBeVisible();
+
+  await expect(
+    page.getByRole('heading', { name: /^2.2 This is another section inside the second section$/ }),
+  ).toBeVisible();
+
+  await expect(
+    page.getByText(/^This paragraph contains additional distinct mock text\.$/),
+  ).toBeVisible();
+});

--- a/tests/unit/sectionNumbering.test.ts
+++ b/tests/unit/sectionNumbering.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { Document, ElementTypes } from '../../src/types';
+import { addSectionNumbering } from '../../src/utils/preprocessDocument';
+
+describe('addSectionNumbering', () => {
+  it('should add numbering to a single top-level section', () => {
+    const document: Document = {
+      title: { type: ElementTypes.Text, content: 'Document Title' },
+      contentElements: [
+        {
+          type: ElementTypes.Section,
+          title: { type: ElementTypes.Text, content: 'Introduction' },
+          contentElements: [],
+        },
+      ],
+    };
+
+    const result = addSectionNumbering(document);
+
+    expect(result.contentElements[0].title.content).toBe('1 Introduction');
+  });
+
+  it('should add numbering to nested sections', () => {
+    const document: Document = {
+      title: { type: ElementTypes.Text, content: 'Document Title' },
+      contentElements: [
+        {
+          type: ElementTypes.Section,
+          title: { type: ElementTypes.Text, content: 'Chapter 1' },
+          contentElements: [
+            {
+              type: ElementTypes.Section,
+              title: { type: ElementTypes.Text, content: 'Section 1.1' },
+              contentElements: [],
+            },
+            {
+              type: ElementTypes.Section,
+              title: { type: ElementTypes.Text, content: 'Section 1.2' },
+              contentElements: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = addSectionNumbering(document);
+
+    expect(result.contentElements[0].title.content).toBe('1 Chapter 1');
+    expect(result.contentElements[0].contentElements[0].title.content).toBe('1.1 Section 1.1');
+    expect(result.contentElements[0].contentElements[1].title.content).toBe('1.2 Section 1.2');
+  });
+
+  it('should handle documents with no sections', () => {
+    const document: Document = {
+      title: { type: ElementTypes.Text, content: 'Empty Document' },
+      contentElements: [],
+    };
+
+    const result = addSectionNumbering(document);
+
+    expect(result.contentElements).toHaveLength(0);
+  });
+
+  it('should handle deeply nested sections', () => {
+    const document: Document = {
+      title: { type: ElementTypes.Text, content: 'Nested Document' },
+      contentElements: [
+        {
+          type: ElementTypes.Section,
+          title: { type: ElementTypes.Text, content: 'Top Level' },
+          contentElements: [
+            {
+              type: ElementTypes.Section,
+              title: { type: ElementTypes.Text, content: 'Second Level' },
+              contentElements: [
+                {
+                  type: ElementTypes.Section,
+                  title: { type: ElementTypes.Text, content: 'Third Level' },
+                  contentElements: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = addSectionNumbering(document);
+
+    expect(result.contentElements[0].title.content).toBe('1 Top Level');
+    expect(result.contentElements[0].contentElements[0].title.content).toBe('1.1 Second Level');
+    expect(result.contentElements[0].contentElements[0].contentElements[0].title.content).toBe(
+      '1.1.1 Third Level',
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/unit/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉 -->

## Summary
This PR introduces the `showSectionNumbering` option to `AdyenDocumentViewerOptions`. 

## Key Changes:
- Added a new `showSectionNumbering` option.
- This option allows toggling the display of numbering for sections and subsections in the document viewer.

## Motivation
- The `showSectionNumbering` option enhances flexibility by allowing users to enable or disable section numbering based on their preferences or requirements.

## Testing
- Verified functionality by enabling and disabling the option.
- Added unit tests and a e2e test to ensure the feature behaves as expected.

## Additional Notes
- Default behavior remains unchanged (numbering is not shown unless explicitly enabled).